### PR TITLE
Reliably calculate one path level per description level

### DIFF
--- a/lib/minitest-vcr/spec.rb
+++ b/lib/minitest-vcr/spec.rb
@@ -8,7 +8,7 @@ module MinitestVcr
       run_before = lambda do |example|
         if metadata[:vcr]
           options = metadata[:vcr].is_a?(Hash) ? metadata[:vcr] : {}
-          VCR.insert_cassette StringHelpers.vcr_path(example.class.name, example, spec_name), options
+          VCR.insert_cassette StringHelpers.vcr_path(example, spec_name), options
         end
       end
 
@@ -24,14 +24,22 @@ module MinitestVcr
 
   module StringHelpers
 
-    def self.vcr_path(example_class_name, example, spec_name)
-      prep(example.class.name).push(spec_name).join("/")
+    def self.vcr_path(example, spec_name)
+      description_stack(example).push(spec_name).join("/")
     end
 
     protected
 
-    def self.prep string
-      string.split("::").map {|e| e.sub(/[^\w]*$/, "")}.reject(&:empty?) - ["vcr"]
+    def self.description_stack(example)
+      frame = example.class
+      stack = []
+
+      while frame != Minitest::Spec do
+        stack.unshift frame.desc.to_s
+        frame = frame.superclass
+      end
+
+      return stack
     end
 
   end

--- a/test/cassettes/MinitestVcr_Spec/a_describe_with_metadata/with_a_nested_example_group/uses_a_cassette_for_any_examples.yml
+++ b/test/cassettes/MinitestVcr_Spec/a_describe_with_metadata/with_a_nested_example_group/uses_a_cassette_for_any_examples.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://example.com/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - ! '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=604800
+      Content-Type:
+      - text/html
+      Date:
+      - Fri, 17 Oct 2014 05:41:47 GMT
+      Etag:
+      - ! '"359670651"'
+      Expires:
+      - Fri, 24 Oct 2014 05:41:47 GMT
+      Last-Modified:
+      - Fri, 09 Aug 2013 23:54:35 GMT
+      Server:
+      - ECS (iad/182A)
+      X-Cache:
+      - HIT
+      X-Ec-Custom-Error:
+      - '1'
+      Content-Length:
+      - '1270'
+    body:
+      encoding: US-ASCII
+      string: ! "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
+        \   <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html;
+        charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width,
+        initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color:
+        #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: \"Open
+        Sans\", \"Helvetica Neue\", Helvetica, Arial, sans-serif;\n        \n    }\n
+        \   div {\n        width: 600px;\n        margin: 5em auto;\n        padding:
+        50px;\n        background-color: #fff;\n        border-radius: 1em;\n    }\n
+        \   a:link, a:visited {\n        color: #38488f;\n        text-decoration:
+        none;\n    }\n    @media (max-width: 700px) {\n        body {\n            background-color:
+        #fff;\n        }\n        div {\n            width: auto;\n            margin:
+        0 auto;\n            border-radius: 0;\n            padding: 1em;\n        }\n
+        \   }\n    </style>    \n</head>\n\n<body>\n<div>\n    <h1>Example Domain</h1>\n
+        \   <p>This domain is established to be used for illustrative examples in
+        documents. You may use this\n    domain in examples without prior coordination
+        or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\">More
+        information...</a></p>\n</div>\n</body>\n</html>\n"
+    http_version: 
+  recorded_at: Fri, 17 Oct 2014 05:41:47 GMT
+recorded_with: VCR 2.9.3

--- a/test/cassettes/MinitestVcr_Spec/an_it_with_metadata/with_a_nested_example_group/can_supply_metadata.yml
+++ b/test/cassettes/MinitestVcr_Spec/an_it_with_metadata/with_a_nested_example_group/can_supply_metadata.yml
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
-      - "*/*"
+      - ! '*/*'
   response:
     status:
       code: 200
@@ -25,15 +25,15 @@ http_interactions:
       Content-Type:
       - text/html
       Date:
-      - Tue, 14 Oct 2014 18:15:53 GMT
+      - Fri, 17 Oct 2014 13:21:14 GMT
       Etag:
-      - '"359670651"'
+      - ! '"359670651"'
       Expires:
-      - Tue, 21 Oct 2014 18:15:53 GMT
+      - Fri, 24 Oct 2014 13:21:14 GMT
       Last-Modified:
       - Fri, 09 Aug 2013 23:54:35 GMT
       Server:
-      - ECS (ftw/FBE4)
+      - ECS (iad/182A)
       X-Cache:
       - HIT
       X-Ec-Custom-Error:
@@ -41,8 +41,8 @@ http_interactions:
       Content-Length:
       - '1270'
     body:
-      encoding: UTF-8
-      string: "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
+      encoding: US-ASCII
+      string: ! "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
         \   <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html;
         charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width,
         initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color:
@@ -60,5 +60,5 @@ http_interactions:
         or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\">More
         information...</a></p>\n</div>\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Tue, 14 Oct 2014 18:15:53 GMT
+  recorded_at: Fri, 17 Oct 2014 13:21:14 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/MinitestVcr_Spec/an_it_with_metadata/with_a_nested_example_group/uses_a_cassette_for_any_examples.yml
+++ b/test/cassettes/MinitestVcr_Spec/an_it_with_metadata/with_a_nested_example_group/uses_a_cassette_for_any_examples.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://example.com/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - ! '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=604800
+      Content-Type:
+      - text/html
+      Date:
+      - Fri, 17 Oct 2014 05:41:47 GMT
+      Etag:
+      - ! '"359670651"'
+      Expires:
+      - Fri, 24 Oct 2014 05:41:47 GMT
+      Last-Modified:
+      - Fri, 09 Aug 2013 23:54:35 GMT
+      Server:
+      - ECS (iad/182A)
+      X-Cache:
+      - HIT
+      X-Ec-Custom-Error:
+      - '1'
+      Content-Length:
+      - '1270'
+    body:
+      encoding: US-ASCII
+      string: ! "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
+        \   <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html;
+        charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width,
+        initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color:
+        #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: \"Open
+        Sans\", \"Helvetica Neue\", Helvetica, Arial, sans-serif;\n        \n    }\n
+        \   div {\n        width: 600px;\n        margin: 5em auto;\n        padding:
+        50px;\n        background-color: #fff;\n        border-radius: 1em;\n    }\n
+        \   a:link, a:visited {\n        color: #38488f;\n        text-decoration:
+        none;\n    }\n    @media (max-width: 700px) {\n        body {\n            background-color:
+        #fff;\n        }\n        div {\n            width: auto;\n            margin:
+        0 auto;\n            border-radius: 0;\n            padding: 1em;\n        }\n
+        \   }\n    </style>    \n</head>\n\n<body>\n<div>\n    <h1>Example Domain</h1>\n
+        \   <p>This domain is established to be used for illustrative examples in
+        documents. You may use this\n    domain in examples without prior coordination
+        or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\">More
+        information...</a></p>\n</div>\n</body>\n</html>\n"
+    http_version: 
+  recorded_at: Fri, 17 Oct 2014 05:41:47 GMT
+recorded_with: VCR 2.9.3

--- a/test/cassettes/MinitestVcr_Spec/nested_describe/example_in_nested_describe.yml
+++ b/test/cassettes/MinitestVcr_Spec/nested_describe/example_in_nested_describe.yml
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
-      - "*/*"
+      - ! '*/*'
   response:
     status:
       code: 200
@@ -25,15 +25,15 @@ http_interactions:
       Content-Type:
       - text/html
       Date:
-      - Tue, 14 Oct 2014 18:15:53 GMT
+      - Fri, 17 Oct 2014 05:41:47 GMT
       Etag:
-      - '"359670651"'
+      - ! '"359670651"'
       Expires:
-      - Tue, 21 Oct 2014 18:15:53 GMT
+      - Fri, 24 Oct 2014 05:41:47 GMT
       Last-Modified:
       - Fri, 09 Aug 2013 23:54:35 GMT
       Server:
-      - ECS (ftw/FBE4)
+      - ECS (iad/182A)
       X-Cache:
       - HIT
       X-Ec-Custom-Error:
@@ -41,8 +41,8 @@ http_interactions:
       Content-Length:
       - '1270'
     body:
-      encoding: UTF-8
-      string: "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
+      encoding: US-ASCII
+      string: ! "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
         \   <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html;
         charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width,
         initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color:
@@ -60,5 +60,5 @@ http_interactions:
         or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\">More
         information...</a></p>\n</div>\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Tue, 14 Oct 2014 18:15:53 GMT
+  recorded_at: Fri, 17 Oct 2014 05:41:47 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/MinitestVcr_Spec/top_level_example.yml
+++ b/test/cassettes/MinitestVcr_Spec/top_level_example.yml
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
-      - "*/*"
+      - ! '*/*'
   response:
     status:
       code: 200
@@ -25,15 +25,15 @@ http_interactions:
       Content-Type:
       - text/html
       Date:
-      - Tue, 14 Oct 2014 18:15:53 GMT
+      - Fri, 17 Oct 2014 05:41:47 GMT
       Etag:
-      - '"359670651"'
+      - ! '"359670651"'
       Expires:
-      - Tue, 21 Oct 2014 18:15:53 GMT
+      - Fri, 24 Oct 2014 05:41:47 GMT
       Last-Modified:
       - Fri, 09 Aug 2013 23:54:35 GMT
       Server:
-      - ECS (ftw/FBE4)
+      - ECS (iad/182A)
       X-Cache:
       - HIT
       X-Ec-Custom-Error:
@@ -41,8 +41,8 @@ http_interactions:
       Content-Length:
       - '1270'
     body:
-      encoding: UTF-8
-      string: "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
+      encoding: US-ASCII
+      string: ! "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
         \   <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html;
         charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width,
         initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color:
@@ -60,5 +60,5 @@ http_interactions:
         or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\">More
         information...</a></p>\n</div>\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Tue, 14 Oct 2014 18:15:53 GMT
+  recorded_at: Fri, 17 Oct 2014 05:41:47 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Some_Crazy_Nested_RandomClass/nested_describe/example_in_nested_describe.yml
+++ b/test/cassettes/Some_Crazy_Nested_RandomClass/nested_describe/example_in_nested_describe.yml
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
-      - "*/*"
+      - ! '*/*'
   response:
     status:
       code: 200
@@ -25,15 +25,15 @@ http_interactions:
       Content-Type:
       - text/html
       Date:
-      - Tue, 14 Oct 2014 18:15:53 GMT
+      - Fri, 17 Oct 2014 13:21:14 GMT
       Etag:
-      - '"359670651"'
+      - ! '"359670651"'
       Expires:
-      - Tue, 21 Oct 2014 18:15:53 GMT
+      - Fri, 24 Oct 2014 13:21:14 GMT
       Last-Modified:
       - Fri, 09 Aug 2013 23:54:35 GMT
       Server:
-      - ECS (ftw/FBE4)
+      - ECS (iad/182A)
       X-Cache:
       - HIT
       X-Ec-Custom-Error:
@@ -41,8 +41,8 @@ http_interactions:
       Content-Length:
       - '1270'
     body:
-      encoding: UTF-8
-      string: "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
+      encoding: US-ASCII
+      string: ! "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
         \   <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html;
         charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width,
         initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color:
@@ -60,5 +60,5 @@ http_interactions:
         or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\">More
         information...</a></p>\n</div>\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Tue, 14 Oct 2014 18:15:53 GMT
+  recorded_at: Fri, 17 Oct 2014 13:21:14 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Some_Crazy_Nested_RandomClass/top_level_example.yml
+++ b/test/cassettes/Some_Crazy_Nested_RandomClass/top_level_example.yml
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
-      - "*/*"
+      - ! '*/*'
   response:
     status:
       code: 200
@@ -25,15 +25,15 @@ http_interactions:
       Content-Type:
       - text/html
       Date:
-      - Tue, 14 Oct 2014 18:15:53 GMT
+      - Fri, 17 Oct 2014 13:21:14 GMT
       Etag:
-      - '"359670651"'
+      - ! '"359670651"'
       Expires:
-      - Tue, 21 Oct 2014 18:15:53 GMT
+      - Fri, 24 Oct 2014 13:21:14 GMT
       Last-Modified:
       - Fri, 09 Aug 2013 23:54:35 GMT
       Server:
-      - ECS (ftw/FBE4)
+      - ECS (iad/182A)
       X-Cache:
       - HIT
       X-Ec-Custom-Error:
@@ -41,8 +41,8 @@ http_interactions:
       Content-Length:
       - '1270'
     body:
-      encoding: UTF-8
-      string: "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
+      encoding: US-ASCII
+      string: ! "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
         \   <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html;
         charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width,
         initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color:
@@ -60,5 +60,5 @@ http_interactions:
         or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\">More
         information...</a></p>\n</div>\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Tue, 14 Oct 2014 18:15:53 GMT
+  recorded_at: Fri, 17 Oct 2014 13:21:14 GMT
 recorded_with: VCR 2.9.3

--- a/test/minitest-vcr/deeply_namespaced_class_as_description_test.rb
+++ b/test/minitest-vcr/deeply_namespaced_class_as_description_test.rb
@@ -1,0 +1,30 @@
+require "helper"
+
+module Some
+  module Crazy
+    module Nested
+      class RandomClass
+      end
+    end
+  end
+end
+
+MinitestVcr::Spec.configure!
+
+describe Some::Crazy::Nested::RandomClass, :vcr do
+  before do
+    conn = Faraday.new
+    @response = conn.get "http://example.com"
+  end
+
+  it "top level example" do
+    VCR.current_cassette.name.must_equal "Some::Crazy::Nested::RandomClass/top level example"
+  end
+
+  describe "nested describe" do
+    it "example in nested describe" do
+      VCR.current_cassette.name.must_equal "Some::Crazy::Nested::RandomClass/nested describe/example in nested describe"
+    end
+  end
+
+end

--- a/test/minitest-vcr/nested_describe_test.rb
+++ b/test/minitest-vcr/nested_describe_test.rb
@@ -9,12 +9,12 @@ describe MinitestVcr::Spec, :vcr => {:tag => :some_tag, :match_requests_on => [:
   end
 
   it "top level example" do
-    VCR.current_cassette.name.must_equal "MinitestVcr/Spec/top level example"
+    VCR.current_cassette.name.must_equal "MinitestVcr::Spec/top level example"
   end
 
   describe "nested describe" do
     it "example in nested describe" do
-      VCR.current_cassette.name.must_equal "MinitestVcr/Spec/nested describe/example in nested describe"
+      VCR.current_cassette.name.must_equal "MinitestVcr::Spec/nested describe/example in nested describe"
     end
   end
 

--- a/test/minitest-vcr/spec_test.rb
+++ b/test/minitest-vcr/spec_test.rb
@@ -12,8 +12,7 @@ describe MinitestVcr::Spec do
       end
       it 'uses a cassette for any examples' do
         (VCR.current_cassette.name.split('/')).must_equal([
-          'MinitestVcr',
-          'Spec',
+          'MinitestVcr::Spec',
           'a describe with metadata',
           'with a nested example group',
           'uses a cassette for any examples'
@@ -30,8 +29,7 @@ describe MinitestVcr::Spec do
       end
       it 'uses a cassette for any examples', :vcr do
         (VCR.current_cassette.name.split('/')).must_equal([
-          'MinitestVcr',
-          'Spec',
+          'MinitestVcr::Spec',
           'an it with metadata',
           'with a nested example group',
           'uses a cassette for any examples'


### PR DESCRIPTION
Okay, I _think_ I might have achieved what we both wanted from #16, in a consistent and reliable way implemented simply. 

There will always be one path component for each level of description: `MinitestVcr::Spec` as a description remains `MinitestVcr::Spec` and turns into `MinitestVcr_Spec` in the file system, instead of two levels `MinitestVcr/Spec`.  While still behaving consistently everywhere else. 

Figured out we could get what we needed out of looking at the `desc` for each description level one by one, instead of trying to parse the `class.name` which has extra stuff in it and has lost the information needed. 

What do you think?
