### PR TITLE
Fix case where no example name could be found.

### DIFF
--- a/lib/minitest-vcr/spec.rb
+++ b/lib/minitest-vcr/spec.rb
@@ -8,7 +8,7 @@ module MinitestVcr
       run_before = lambda do |example|
         if metadata[:vcr]
           options = metadata[:vcr].is_a?(Hash) ? metadata[:vcr] : {}
-          VCR.insert_cassette StringHelpers.vcr_path(example, spec_name), options
+          VCR.insert_cassette StringHelpers.vcr_path(example), options
         end
       end
 
@@ -24,8 +24,8 @@ module MinitestVcr
 
   module StringHelpers
 
-    def self.vcr_path(example, spec_name)
-      description_stack(example).push(spec_name).join("/")
+    def self.vcr_path(example)
+      description_stack(example).push(extract_example_description(example)).join("/")
     end
 
     protected
@@ -40,6 +40,17 @@ module MinitestVcr
       end
 
       return stack
+    end
+
+    # Minitest::Spec takes the example description and writes
+    # a test_NNNN_ in front of it, and doesn't actually keep
+    # the original anywhere. Okay, we'll take it out.
+    def self.extract_example_description(example)
+      if (example.name =~ /\Atest_\d{4}_(.*)\z/)
+        return $1
+      else
+        return example.name
+      end
     end
 
   end

--- a/test/cassettes/top_level_describe/an_inner_describe/a_test_inside_inner_describe.yml
+++ b/test/cassettes/top_level_describe/an_inner_describe/a_test_inside_inner_describe.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://example.com/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - ! '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=604800
+      Content-Type:
+      - text/html
+      Date:
+      - Mon, 20 Oct 2014 22:44:12 GMT
+      Etag:
+      - ! '"359670651"'
+      Expires:
+      - Mon, 27 Oct 2014 22:44:12 GMT
+      Last-Modified:
+      - Fri, 09 Aug 2013 23:54:35 GMT
+      Server:
+      - ECS (iad/182A)
+      X-Cache:
+      - HIT
+      X-Ec-Custom-Error:
+      - '1'
+      Content-Length:
+      - '1270'
+    body:
+      encoding: US-ASCII
+      string: ! "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
+        \   <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html;
+        charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width,
+        initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color:
+        #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: \"Open
+        Sans\", \"Helvetica Neue\", Helvetica, Arial, sans-serif;\n        \n    }\n
+        \   div {\n        width: 600px;\n        margin: 5em auto;\n        padding:
+        50px;\n        background-color: #fff;\n        border-radius: 1em;\n    }\n
+        \   a:link, a:visited {\n        color: #38488f;\n        text-decoration:
+        none;\n    }\n    @media (max-width: 700px) {\n        body {\n            background-color:
+        #fff;\n        }\n        div {\n            width: auto;\n            margin:
+        0 auto;\n            border-radius: 0;\n            padding: 1em;\n        }\n
+        \   }\n    </style>    \n</head>\n\n<body>\n<div>\n    <h1>Example Domain</h1>\n
+        \   <p>This domain is established to be used for illustrative examples in
+        documents. You may use this\n    domain in examples without prior coordination
+        or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\">More
+        information...</a></p>\n</div>\n</body>\n</html>\n"
+    http_version: 
+  recorded_at: Mon, 20 Oct 2014 22:44:12 GMT
+recorded_with: VCR 2.9.3

--- a/test/minitest-vcr/nested_describe_test.rb
+++ b/test/minitest-vcr/nested_describe_test.rb
@@ -19,3 +19,18 @@ describe MinitestVcr::Spec, :vcr => {:tag => :some_tag, :match_requests_on => [:
   end
 
 end
+
+
+describe "top level describe", :vcr do    
+  describe "an inner describe" do
+    it "a test inside inner describe" do
+      conn = Faraday.new
+      @response = conn.get "http://example.com"
+
+      VCR.current_cassette.name.must_equal "top level describe/an inner describe/a test inside inner describe"
+    end
+  end
+
+  it "makes a request succesfully" do
+  end
+end


### PR DESCRIPTION
Fix by no longer using minispec-metadata's #spec_name, but
just extracting description from example.name.

Not sure why minispec-metadata's #spec_name was failing, but the
new test case here demonstrates it failing. Turns out minitest/spec
itself simply doesn't keep track of the original description.
minispec-metadata was trying, but failed for some reason. We won't
try to keep track of it, but instead we'll try to extract it from
what minitest/spec does have, "test_NNNN_original example desc".

I didn't know what to do if (in some future version of minitest?),
the example name wasn't of this format, if I should raise or what.
I just used the original full "test_NNNN_x" or whatever in that case.
