### PR TITLE
Fix bug with overriding #setup/#teardown on Minitest::Spec

### DIFF
--- a/lib/minitest-vcr/spec.rb
+++ b/lib/minitest-vcr/spec.rb
@@ -3,23 +3,24 @@ require "minispec-metadata"
 
 module MinitestVcr
   module Spec
-
-    def self.configure!
-      run_before = lambda do |example|
+    module SetupAndTeardown
+      def setup
+        super
         if metadata[:vcr]
           options = metadata[:vcr].is_a?(Hash) ? metadata[:vcr] : {}
-          VCR.insert_cassette StringHelpers.vcr_path(example), options
+          VCR.insert_cassette StringHelpers.vcr_path(self), options
         end
       end
 
-      run_after = lambda do |example|
+      def teardown
+        super
         ::VCR.eject_cassette if metadata[:vcr]
       end
-
-      ::MiniTest::Spec.before :each, &run_before
-      ::MiniTest::Spec.after :each, &run_after
     end
 
+    def self.configure!
+      ::MiniTest::Spec.send(:include, SetupAndTeardown)
+    end
   end # Spec
 
   module StringHelpers

--- a/minitest-vcr.gemspec
+++ b/minitest-vcr.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "faraday",            "~> 0.9"
   spec.add_development_dependency "rubygems-tasks",     "~> 0.2"
   spec.add_development_dependency "yard",               "~> 0.8"
-  spec.add_development_dependency "webmock",            "~> 1.17"
+  spec.add_development_dependency "webmock"
 end

--- a/minitest-vcr.gemspec
+++ b/minitest-vcr.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "faraday",            "~> 0.9"
   spec.add_development_dependency "rubygems-tasks",     "~> 0.2"
   spec.add_development_dependency "yard",               "~> 0.8"
-  spec.add_development_dependency "webmock"
+  spec.add_development_dependency "webmock",            "~> 1.17"
 end

--- a/test/cassettes/MinitestVcr_Spec/an_it_with_metadata/with_a_nested_example_group/can_supply_metadata.yml
+++ b/test/cassettes/MinitestVcr_Spec/an_it_with_metadata/with_a_nested_example_group/can_supply_metadata.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.9.1
+      - Faraday v0.12.1
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -25,23 +25,23 @@ http_interactions:
       Content-Type:
       - text/html
       Date:
-      - Tue, 31 Mar 2015 20:03:52 GMT
+      - Mon, 03 Jul 2017 19:23:43 GMT
       Etag:
       - '"359670651"'
       Expires:
-      - Tue, 07 Apr 2015 20:03:52 GMT
+      - Mon, 10 Jul 2017 19:23:43 GMT
       Last-Modified:
       - Fri, 09 Aug 2013 23:54:35 GMT
       Server:
-      - ECS (sjc/16A4)
+      - ECS (dfw/27FD)
+      Vary:
+      - Accept-Encoding
       X-Cache:
       - HIT
-      X-Ec-Custom-Error:
-      - '1'
       Content-Length:
-      - '1270'
+      - '606'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
         \   <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html;
         charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width,
@@ -60,5 +60,5 @@ http_interactions:
         or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\">More
         information...</a></p>\n</div>\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Tue, 31 Mar 2015 20:03:52 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Mon, 03 Jul 2017 19:23:43 GMT
+recorded_with: VCR 3.0.3

--- a/test/cassettes/MinitestVcr_Spec/an_it_with_metadata/with_a_nested_example_group/can_supply_metadata.yml
+++ b/test/cassettes/MinitestVcr_Spec/an_it_with_metadata/with_a_nested_example_group/can_supply_metadata.yml
@@ -25,15 +25,15 @@ http_interactions:
       Content-Type:
       - text/html
       Date:
-      - Mon, 03 Jul 2017 19:23:43 GMT
+      - Mon, 03 Jul 2017 19:30:55 GMT
       Etag:
-      - '"359670651"'
+      - '"359670651+gzip"'
       Expires:
-      - Mon, 10 Jul 2017 19:23:43 GMT
+      - Mon, 10 Jul 2017 19:30:55 GMT
       Last-Modified:
       - Fri, 09 Aug 2013 23:54:35 GMT
       Server:
-      - ECS (dfw/27FD)
+      - ECS (dfw/279D)
       Vary:
       - Accept-Encoding
       X-Cache:
@@ -60,5 +60,5 @@ http_interactions:
         or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\">More
         information...</a></p>\n</div>\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Mon, 03 Jul 2017 19:23:43 GMT
+  recorded_at: Mon, 03 Jul 2017 19:30:55 GMT
 recorded_with: VCR 3.0.3

--- a/test/minitest-vcr/spec_test.rb
+++ b/test/minitest-vcr/spec_test.rb
@@ -43,13 +43,9 @@ describe MinitestVcr::Spec do
 
   describe "#configure!", :vcr do
 
-    before do
-      ::MiniTest::Spec.expects(:before).with(:each)
-      ::MiniTest::Spec.expects(:after).with(:each)
-    end
-
-    it "should call before and after with proper args and block" do
+    it "should include setup and teardown module into Minitest::Spec" do
       MinitestVcr::Spec.configure!
+      Minitest::Spec.included_modules.must_include(MinitestVcr::Spec::SetupAndTeardown)
     end
   end
 end


### PR DESCRIPTION
Addresses #24.

Now other gems can extend the setup and teardown methods with their own modules.