### PR TITLE
Add first class support for `ActiveSupport::TestCase`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.3
 
 script: bundle exec rake
+  - 2.3
+  - 2.4
+  - 2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 rvm:
-
-script: bundle exec rake
   - 2.3
   - 2.4
   - 2.5

--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,10 @@ source 'https://rubygems.org'
 gem 'coveralls', require: false
 
 group :development, :test do
-  gem "mocha",   "~> 1.7"
-  gem "faraday", "~> 0.15.3"
-  gem "yard",    "~> 0.9.16"
-  gem "webmock", "~> 3.4", ">= 3.4.2"
+  gem 'faraday', '~> 0.15.3'
+  gem 'mocha',   '~> 1.7'
+  gem 'webmock', '~> 3.4', '>= 3.4.2'
+  gem 'yard',    '~> 0.9.16', require: false
 end
 
 # Specify your gem's dependencies in minitest-vcr.gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ source 'https://rubygems.org'
 gem 'coveralls', require: false
 
 group :development, :test do
-  gem "bundler", "~> 1.16", ">= 1.16.6"
-  gem "rake",    "~> 12.3", ">= 12.3.1"
   gem "mocha",   "~> 1.7"
   gem "faraday", "~> 0.15.3"
   gem "yard",    "~> 0.9.16"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,17 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'coveralls', require: false
 
+group :development, :test do
+  gem "bundler", "~> 1.16", ">= 1.16.6"
+  gem "rake",    "~> 12.3", ">= 12.3.1"
+  gem "mocha",   "~> 1.7"
+  gem "faraday", "~> 0.15.3"
+  gem "yard",    "~> 0.9.16"
+  gem "webmock", "~> 3.4", ">= 3.4.2"
+end
+
 # Specify your gem's dependencies in minitest-vcr.gemspec
 gemspec
-

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ minitest-vcr
 | Gem name                |  minitest-vcr      |
 | License                 |  [MIT](LICENSE.txt)   |
 | Version                 |  [![Gem Version](https://badge.fury.io/rb/minitest-vcr.svg)](https://badge.fury.io/rb/minitest-vcr) |
-| Continuous Integration  |  [![Build Status](https://travis-ci.com/mfpiccolo/minitest-vcr.svg?branch=master)](https://travis-ci.com/mfpiccolo/minitest-vcr)
+| Continuous Integration  |  [![Build Status](https://travis-ci.org/mfpiccolo/minitest-vcr.svg?branch=master)](https://travis-ci.org/mfpiccolo/minitest-vcr)
 | Test Coverage           |  [![Coverage Status](https://coveralls.io/repos/github/mfpiccolo/minitest-vcr/badge.svg?branch=master)](https://coveralls.io/github/mfpiccolo/minitest-vcr?branch=master)
 | Grade                   |  [![Maintainability](https://api.codeclimate.com/v1/badges/9627118e4e89447cb51a/maintainability)](https://codeclimate.com/github/mfpiccolo/minitest-vcr/maintainability)
 | Homepage                |  [http://mfpiccolo.github.io/minitest-vcr][homepage] |

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ minitest-vcr
 | Gem name                |  minitest-vcr      |
 | License                 |  [MIT](LICENSE.txt)   |
 | Version                 |  [![Gem Version](https://badge.fury.io/rb/minitest-vcr.png)](http://badge.fury.io/rb/minitest-vcr) |
-| Continuous Integration  |  [![Build Status](https://travis-ci.org/mfpiccolo/minitest-vcr.png?branch=master)](https://travis-ci.org/mfpiccolo/minitest-vcr)
-| Test Coverage           |  [![Coverage Status](https://coveralls.io/repos/mfpiccolo/minitest-vcr/badge.png?branch=master)](https://coveralls.io/r/mfpiccolo/minitest-vcr?branch=coveralls)
-| Grade                   |  [![Code Climate](https://codeclimate.com/github/mfpiccolo/minitest-vcr.png)](https://codeclimate.com/github/mfpiccolo/minitest-vcr)
+| Continuous Integration  |  [![Build Status](https://travis-ci.com/mfpiccolo/minitest-vcr.svg?branch=master)](https://travis-ci.com/mfpiccolo/minitest-vcr)
+| Test Coverage           |  [![Coverage Status](https://coveralls.io/repos/github/mfpiccolo/minitest-vcr/badge.svg?branch=master)](https://coveralls.io/github/mfpiccolo/minitest-vcr?branch=master)
+| Grade                   |  [![Maintainability](https://api.codeclimate.com/v1/badges/9627118e4e89447cb51a/maintainability)](https://codeclimate.com/github/mfpiccolo/minitest-vcr/maintainability)
 | Homepage                |  [http://mfpiccolo.github.io/minitest-vcr][homepage] |
 | Documentation           |  [http://rdoc.info/github/mfpiccolo/minitest-vcr/frames][documentation] |
 | Issues                  |  [https://github.com/mfpiccolo/minitest-vcr/issues][issues] |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ minitest-vcr
 |------------------------ | ----------------- |
 | Gem name                |  minitest-vcr      |
 | License                 |  [MIT](LICENSE.txt)   |
-| Version                 |  [![Gem Version](https://badge.fury.io/rb/minitest-vcr.png)](http://badge.fury.io/rb/minitest-vcr) |
+| Version                 |  [![Gem Version](https://badge.fury.io/rb/minitest-vcr.svg)](https://badge.fury.io/rb/minitest-vcr) |
 | Continuous Integration  |  [![Build Status](https://travis-ci.com/mfpiccolo/minitest-vcr.svg?branch=master)](https://travis-ci.com/mfpiccolo/minitest-vcr)
 | Test Coverage           |  [![Coverage Status](https://coveralls.io/repos/github/mfpiccolo/minitest-vcr/badge.svg?branch=master)](https://coveralls.io/github/mfpiccolo/minitest-vcr?branch=master)
 | Grade                   |  [![Maintainability](https://api.codeclimate.com/v1/badges/9627118e4e89447cb51a/maintainability)](https://codeclimate.com/github/mfpiccolo/minitest-vcr/maintainability)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ minitest-vcr
 | Continuous Integration  |  [![Build Status](https://travis-ci.org/mfpiccolo/minitest-vcr.png?branch=master)](https://travis-ci.org/mfpiccolo/minitest-vcr)
 | Test Coverage           |  [![Coverage Status](https://coveralls.io/repos/mfpiccolo/minitest-vcr/badge.png?branch=master)](https://coveralls.io/r/mfpiccolo/minitest-vcr?branch=coveralls)
 | Grade                   |  [![Code Climate](https://codeclimate.com/github/mfpiccolo/minitest-vcr.png)](https://codeclimate.com/github/mfpiccolo/minitest-vcr)
-| Dependencies            |  [![Dependency Status](https://gemnasium.com/mfpiccolo/minitest-vcr.png)](https://gemnasium.com/mfpiccolo/minitest-vcr)
 | Homepage                |  [http://mfpiccolo.github.io/minitest-vcr][homepage] |
 | Documentation           |  [http://rdoc.info/github/mfpiccolo/minitest-vcr/frames][documentation] |
 | Issues                  |  [https://github.com/mfpiccolo/minitest-vcr/issues][issues] |

--- a/Rakefile
+++ b/Rakefile
@@ -1,34 +1,17 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-require 'rubygems'
-
-begin
-  require 'bundler'
-rescue LoadError => e
-  warn e.message
-  warn "Run `gem install bundler` to install Bundler."
-  exit -1
-end
-
-begin
-  Bundler.setup(:development)
-rescue Bundler::BundlerError => e
-  warn e.message
-  warn "Run `bundle install` to install missing gems."
-  exit e.status_code
-end
-
-require 'rake'
+require 'bundler/gem_tasks'
 require 'rake/testtask'
 
-Rake::TestTask.new do |test|
-  test.libs << 'test'
-  test.pattern = 'test/**/*_test.rb'
-  test.verbose = true
+Rake::TestTask.new(:test) do |t|
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.test_files = FileList['test/**/*_test.rb']
+  t.verbose = true
 end
+
+task default: :test
 
 require 'yard'
 YARD::Rake::YardocTask.new
-task :doc => :yard
-
-task :default => :test
+task doc: :yard

--- a/Rakefile
+++ b/Rakefile
@@ -19,10 +19,6 @@ rescue Bundler::BundlerError => e
 end
 
 require 'rake'
-
-require 'rubygems/tasks'
-Gem::Tasks.new
-
 require 'rake/testtask'
 
 Rake::TestTask.new do |test|
@@ -36,4 +32,3 @@ YARD::Rake::YardocTask.new
 task :doc => :yard
 
 task :default => :test
-

--- a/lib/minitest-vcr.rb
+++ b/lib/minitest-vcr.rb
@@ -1,5 +1,6 @@
 require "minitest-vcr/version"
 require "minitest-vcr/spec"
+require "minitest-vcr/active_support/test_case"
 
 module MinitestVcr
   def self.included(base)

--- a/lib/minitest-vcr/active_support/test_case.rb
+++ b/lib/minitest-vcr/active_support/test_case.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'vcr'
+require 'active_support/testing/metadata'
+
+module MinitestVcr
+  module ActiveSupport
+    module TestCase
+    end
+  end
+end

--- a/lib/minitest-vcr/active_support/test_case.rb
+++ b/lib/minitest-vcr/active_support/test_case.rb
@@ -6,6 +6,30 @@ require 'active_support/testing/metadata'
 module MinitestVcr
   module ActiveSupport
     module TestCase
+      def before_setup
+        super
+
+        return unless metadata.key?(:vcr)
+
+        base_path = self.class.name.split('::').map do |p|
+          p.underscore.tr(' ', '_')
+        end
+
+        base_path = File.join(*base_path)
+
+        file_name = name.gsub(/^test_.\d+_/, ' ').strip.tr(' ', '_')
+        path      = File.join(base_path, file_name)
+
+        options = metadata[:vcr].is_a?(Hash) ? metadata[:vcr] : {}
+
+        ::VCR.insert_cassette(path, options)
+      end
+
+      def after_teardown
+        ::VCR.eject_cassette if metadata.key?(:vcr)
+
+        super
+      end
     end
   end
 end

--- a/lib/minitest-vcr/spec.rb
+++ b/lib/minitest-vcr/spec.rb
@@ -55,25 +55,3 @@ module MinitestVcr
 
   end
 end # MinitestVcr
-
-if defined? ActiveSupport::TestCase
-  class ActiveSupport::TestCase
-    def before_setup
-      super
-      if self.class.name.match("::vcr::")
-        base_path = self.class.name.split("::")
-          .map {|p| p.underscore.gsub(" ", "_") unless p == "vcr" }.join("/")
-
-        file_name = name.gsub(/^test_.\d+_/, " ").strip.gsub(" ", "_")
-        VCR.insert_cassette(base_path + "/" + file_name)
-      end
-    end
-
-    def after_teardown
-      if self.class.name.match("::vcr::")
-        ::VCR.eject_cassette
-      end
-      super
-    end
-  end
-end

--- a/lib/minitest-vcr/spec.rb
+++ b/lib/minitest-vcr/spec.rb
@@ -3,23 +3,24 @@ require "minispec-metadata"
 
 module MinitestVcr
   module Spec
-
-    def self.configure!
-      run_before = lambda do |example|
+    module SetupAndTeardown
+      def setup
+        super
         if metadata[:vcr]
           options = metadata[:vcr].is_a?(Hash) ? metadata[:vcr] : {}
-          VCR.insert_cassette StringHelpers.vcr_path(example), options
+          VCR.insert_cassette StringHelpers.vcr_path(self), options
         end
       end
 
-      run_after = lambda do |example|
+      def teardown
+        super
         ::VCR.eject_cassette if metadata[:vcr]
       end
-
-      ::MiniTest::Spec.before :each, &run_before
-      ::MiniTest::Spec.after :each, &run_after
     end
 
+    def self.configure!
+      ::MiniTest::Spec.send(:include, SetupAndTeardown)
+    end
   end # Spec
 
   module StringHelpers

--- a/minitest-vcr.gemspec
+++ b/minitest-vcr.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "faraday",            "~> 0.9"
   spec.add_development_dependency "rubygems-tasks",     "~> 0.2"
   spec.add_development_dependency "yard",               "~> 0.8"
-  spec.add_development_dependency "webmock",            "~> 1.17"
+  spec.add_development_dependency "webmock"
 end

--- a/minitest-vcr.gemspec
+++ b/minitest-vcr.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "vcr",                            ">= 2.9"
   spec.add_dependency "minitest",                       ">= 4.7.5"
   spec.add_dependency "minispec-metadata",              "~> 2.0"
+  spec.add_dependency "activesupport-testing-metadata", "~> 0.1.0"
 
   spec.add_development_dependency "bundler",            "~> 1.5"
   spec.add_development_dependency "rake",               "~> 10.0"

--- a/minitest-vcr.gemspec
+++ b/minitest-vcr.gemspec
@@ -14,12 +14,20 @@ Gem::Specification.new do |spec|
   spec.homepage      = ""
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "vcr",               ">= 2.9"
-  spec.add_dependency "minitest",          ">= 5"
   spec.add_dependency "minispec-metadata", "~> 3.0"
+  spec.add_dependency "minitest",          ">= 5"
+  spec.add_dependency "vcr",               ">= 2.9"
+
+  spec.add_development_dependency "bundler",  "~> 1.16"
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake",     "~> 10.0"
 end

--- a/minitest-vcr.gemspec
+++ b/minitest-vcr.gemspec
@@ -24,10 +24,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "minispec-metadata", "~> 3.0"
-  spec.add_dependency "minitest",          ">= 5"
+  spec.add_dependency "minitest",          ">= 5.0"
   spec.add_dependency "vcr",               ">= 2.9"
 
-  spec.add_development_dependency "bundler",  "~> 1.16"
-  spec.add_development_dependency "minitest", "~> 5.0"
-  spec.add_development_dependency "rake",     "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "rake",    "~> 10.0"
 end

--- a/minitest-vcr.gemspec
+++ b/minitest-vcr.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "faraday",            "~> 0.9"
   spec.add_development_dependency "rubygems-tasks",     "~> 0.2"
   spec.add_development_dependency "yard",               "~> 0.8"
-  spec.add_development_dependency "webmock",            "~> 1.17"
+  spec.add_development_dependency "webmock",            ">= 3.4.2"
 end

--- a/minitest-vcr.gemspec
+++ b/minitest-vcr.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "faraday",            "~> 0.9"
   spec.add_development_dependency "rubygems-tasks",     "~> 0.2"
   spec.add_development_dependency "yard",               "~> 0.8"
-  spec.add_development_dependency "webmock"
+  spec.add_development_dependency "webmock",            "~> 1.17"
 end

--- a/minitest-vcr.gemspec
+++ b/minitest-vcr.gemspec
@@ -1,5 +1,6 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'minitest-vcr/version'
 
@@ -18,15 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "vcr",                            ">= 2.9"
-  spec.add_dependency "minitest",                       ">= 4.7.5"
-  spec.add_dependency "minispec-metadata",              "~> 2.0"
-
-  spec.add_development_dependency "bundler",            "~> 1.5"
-  spec.add_development_dependency "rake",               "~> 10.0"
-  spec.add_development_dependency "mocha",              "~> 1.0"
-  spec.add_development_dependency "faraday",            "~> 0.9"
-  spec.add_development_dependency "rubygems-tasks",     "~> 0.2"
-  spec.add_development_dependency "yard",               "~> 0.8"
-  spec.add_development_dependency "webmock",            "~> 1.17"
+  spec.add_dependency "vcr",               ">= 2.9"
+  spec.add_dependency "minitest",          ">= 5"
+  spec.add_dependency "minispec-metadata", "~> 3.0"
 end

--- a/test/cassettes/MinitestVcr_Spec/an_it_with_metadata/with_a_nested_example_group/can_supply_metadata.yml
+++ b/test/cassettes/MinitestVcr_Spec/an_it_with_metadata/with_a_nested_example_group/can_supply_metadata.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.12.1
+      - Faraday v0.15.3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -23,17 +23,17 @@ http_interactions:
       Cache-Control:
       - max-age=604800
       Content-Type:
-      - text/html
+      - text/html; charset=UTF-8
       Date:
-      - Mon, 03 Jul 2017 19:30:55 GMT
+      - Sat, 13 Oct 2018 14:50:44 GMT
       Etag:
-      - '"359670651+gzip"'
+      - '"1541025663+ident"'
       Expires:
-      - Mon, 10 Jul 2017 19:30:55 GMT
+      - Sat, 20 Oct 2018 14:50:44 GMT
       Last-Modified:
       - Fri, 09 Aug 2013 23:54:35 GMT
       Server:
-      - ECS (dfw/279D)
+      - ECS (ord/4CD5)
       Vary:
       - Accept-Encoding
       X-Cache:
@@ -60,5 +60,5 @@ http_interactions:
         or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\">More
         information...</a></p>\n</div>\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Mon, 03 Jul 2017 19:30:55 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Sat, 13 Oct 2018 14:50:44 GMT
+recorded_with: VCR 4.0.0

--- a/test/cassettes/MinitestVcr_Spec/an_it_with_metadata/with_a_nested_example_group/can_supply_metadata.yml
+++ b/test/cassettes/MinitestVcr_Spec/an_it_with_metadata/with_a_nested_example_group/can_supply_metadata.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.9.1
+      - Faraday v0.12.1
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -25,23 +25,23 @@ http_interactions:
       Content-Type:
       - text/html
       Date:
-      - Tue, 31 Mar 2015 20:03:52 GMT
+      - Mon, 03 Jul 2017 19:23:43 GMT
       Etag:
       - '"359670651"'
       Expires:
-      - Tue, 07 Apr 2015 20:03:52 GMT
+      - Mon, 10 Jul 2017 19:23:43 GMT
       Last-Modified:
       - Fri, 09 Aug 2013 23:54:35 GMT
       Server:
-      - ECS (sjc/16A4)
+      - ECS (dfw/27FD)
+      Vary:
+      - Accept-Encoding
       X-Cache:
       - HIT
-      X-Ec-Custom-Error:
-      - '1'
       Content-Length:
-      - '1270'
+      - '606'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
         \   <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html;
         charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width,
@@ -60,5 +60,5 @@ http_interactions:
         or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\">More
         information...</a></p>\n</div>\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Tue, 31 Mar 2015 20:03:52 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Mon, 03 Jul 2017 19:23:43 GMT
+recorded_with: VCR 3.0.3

--- a/test/cassettes/MinitestVcr_Spec/an_it_with_metadata/with_a_nested_example_group/can_supply_metadata.yml
+++ b/test/cassettes/MinitestVcr_Spec/an_it_with_metadata/with_a_nested_example_group/can_supply_metadata.yml
@@ -25,11 +25,11 @@ http_interactions:
       Content-Type:
       - text/html; charset=UTF-8
       Date:
-      - Sat, 13 Oct 2018 14:50:44 GMT
+      - Sat, 13 Oct 2018 15:13:45 GMT
       Etag:
       - '"1541025663+ident"'
       Expires:
-      - Sat, 20 Oct 2018 14:50:44 GMT
+      - Sat, 20 Oct 2018 15:13:45 GMT
       Last-Modified:
       - Fri, 09 Aug 2013 23:54:35 GMT
       Server:
@@ -60,5 +60,5 @@ http_interactions:
         or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\">More
         information...</a></p>\n</div>\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Sat, 13 Oct 2018 14:50:44 GMT
+  recorded_at: Sat, 13 Oct 2018 15:13:45 GMT
 recorded_with: VCR 4.0.0

--- a/test/cassettes/MinitestVcr_Spec/an_it_with_metadata/with_a_nested_example_group/can_supply_metadata.yml
+++ b/test/cassettes/MinitestVcr_Spec/an_it_with_metadata/with_a_nested_example_group/can_supply_metadata.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.9.1
+      - Faraday v0.15.2
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -23,25 +23,25 @@ http_interactions:
       Cache-Control:
       - max-age=604800
       Content-Type:
-      - text/html
+      - text/html; charset=UTF-8
       Date:
-      - Tue, 31 Mar 2015 20:03:52 GMT
+      - Sun, 09 Sep 2018 01:24:50 GMT
       Etag:
-      - '"359670651"'
+      - '"1541025663+gzip"'
       Expires:
-      - Tue, 07 Apr 2015 20:03:52 GMT
+      - Sun, 16 Sep 2018 01:24:50 GMT
       Last-Modified:
       - Fri, 09 Aug 2013 23:54:35 GMT
       Server:
-      - ECS (sjc/16A4)
+      - ECS (ord/4CB8)
+      Vary:
+      - Accept-Encoding
       X-Cache:
       - HIT
-      X-Ec-Custom-Error:
-      - '1'
       Content-Length:
-      - '1270'
+      - '606'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
         \   <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html;
         charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width,
@@ -60,5 +60,5 @@ http_interactions:
         or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\">More
         information...</a></p>\n</div>\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Tue, 31 Mar 2015 20:03:52 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Sun, 09 Sep 2018 01:24:50 GMT
+recorded_with: VCR 4.0.0

--- a/test/cassettes/MinitestVcr_Spec/an_it_with_metadata/with_a_nested_example_group/can_supply_metadata.yml
+++ b/test/cassettes/MinitestVcr_Spec/an_it_with_metadata/with_a_nested_example_group/can_supply_metadata.yml
@@ -25,15 +25,15 @@ http_interactions:
       Content-Type:
       - text/html
       Date:
-      - Mon, 03 Jul 2017 19:23:43 GMT
+      - Mon, 03 Jul 2017 19:30:55 GMT
       Etag:
-      - '"359670651"'
+      - '"359670651+gzip"'
       Expires:
-      - Mon, 10 Jul 2017 19:23:43 GMT
+      - Mon, 10 Jul 2017 19:30:55 GMT
       Last-Modified:
       - Fri, 09 Aug 2013 23:54:35 GMT
       Server:
-      - ECS (dfw/27FD)
+      - ECS (dfw/279D)
       Vary:
       - Accept-Encoding
       X-Cache:
@@ -60,5 +60,5 @@ http_interactions:
         or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\">More
         information...</a></p>\n</div>\n</body>\n</html>\n"
     http_version: 
-  recorded_at: Mon, 03 Jul 2017 19:23:43 GMT
+  recorded_at: Mon, 03 Jul 2017 19:30:55 GMT
 recorded_with: VCR 3.0.3

--- a/test/cassettes/minitest_vcr/active_support/test_case_test/test_create_a_cassette_name_with_the_proper_path.yml
+++ b/test/cassettes/minitest_vcr/active_support/test_case_test/test_create_a_cassette_name_with_the_proper_path.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://example.com/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=604800
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Sun, 09 Sep 2018 01:24:50 GMT
+      Etag:
+      - '"1541025663+gzip"'
+      Expires:
+      - Sun, 16 Sep 2018 01:24:50 GMT
+      Last-Modified:
+      - Fri, 09 Aug 2013 23:54:35 GMT
+      Server:
+      - ECS (ord/573A)
+      Vary:
+      - Accept-Encoding
+      X-Cache:
+      - HIT
+      Content-Length:
+      - '606'
+    body:
+      encoding: ASCII-8BIT
+      string: "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
+        \   <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html;
+        charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width,
+        initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color:
+        #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: \"Open
+        Sans\", \"Helvetica Neue\", Helvetica, Arial, sans-serif;\n        \n    }\n
+        \   div {\n        width: 600px;\n        margin: 5em auto;\n        padding:
+        50px;\n        background-color: #fff;\n        border-radius: 1em;\n    }\n
+        \   a:link, a:visited {\n        color: #38488f;\n        text-decoration:
+        none;\n    }\n    @media (max-width: 700px) {\n        body {\n            background-color:
+        #fff;\n        }\n        div {\n            width: auto;\n            margin:
+        0 auto;\n            border-radius: 0;\n            padding: 1em;\n        }\n
+        \   }\n    </style>    \n</head>\n\n<body>\n<div>\n    <h1>Example Domain</h1>\n
+        \   <p>This domain is established to be used for illustrative examples in
+        documents. You may use this\n    domain in examples without prior coordination
+        or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\">More
+        information...</a></p>\n</div>\n</body>\n</html>\n"
+    http_version: 
+  recorded_at: Sun, 09 Sep 2018 01:24:50 GMT
+recorded_with: VCR 4.0.0

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -19,6 +19,7 @@ end
 
 require "minitest/autorun"
 require "minispec-metadata"
+require "active_support/testing/metadata"
 require "vcr"
 require "minitest-vcr"
 require "webmock"

--- a/test/minitest-vcr/active_support/test_case_test.rb
+++ b/test/minitest-vcr/active_support/test_case_test.rb
@@ -1,0 +1,17 @@
+require "helper"
+
+class ActiveSupport::TestCase
+  include MinitestVcr::ActiveSupport::TestCase
+end
+
+class MinitestVcr::ActiveSupport::TestCaseTest < ActiveSupport::TestCase
+  test 'create a cassette name with the proper path', :vcr do
+    conn = Faraday.new
+    @response = conn.get 'http://example.com'
+
+    expected = File.join(self.class.name.underscore, name)
+    actual   = VCR.current_cassette.name
+
+    assert_equal expected, actual
+  end
+end

--- a/test/minitest-vcr/spec_test.rb
+++ b/test/minitest-vcr/spec_test.rb
@@ -43,13 +43,9 @@ describe MinitestVcr::Spec do
 
   describe "#configure!", :vcr do
 
-    before do
-      ::MiniTest::Spec.expects(:before).with(:each)
-      ::MiniTest::Spec.expects(:after).with(:each)
-    end
-
-    it "should call before and after with proper args and block" do
+    it "should include setup and teardown module into Minitest::Spec" do
       MinitestVcr::Spec.configure!
+      Minitest::Spec.included_modules.must_include(MinitestVcr::Spec::SetupAndTeardown)
     end
   end
 end


### PR DESCRIPTION
In order to pass the `:vcr` metadata along to the spec, `MiniTestSpec` leans on `minitest-spec-metadata`.

For `ActiveSupport::TestCase` we can use [`active-support-testing-metadata`](https://github.com/y-yagi/activesupport-testing-metadata) to pass along the same metadata.

This PR removes the old conditional for `ActiveSupport::TestCase` and updates it with first class support.

Feedback welcome and appreciated ✨ 