### PR TITLE
use Minitest instead of MiniTest

### DIFF
--- a/lib/minitest-vcr/spec.rb
+++ b/lib/minitest-vcr/spec.rb
@@ -16,8 +16,8 @@ module MinitestVcr
         ::VCR.eject_cassette if metadata[:vcr]
       end
 
-      ::MiniTest::Spec.before :each, &run_before
-      ::MiniTest::Spec.after :each, &run_after
+      ::Minitest::Spec.before :each, &run_before
+      ::Minitest::Spec.after :each, &run_after
     end
 
   end # Spec

--- a/minitest-vcr.gemspec
+++ b/minitest-vcr.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.version       = MinitestVcr::VERSION
   spec.authors       = ["Mike Piccolo"]
   spec.email         = ["mpiccolo@newleaders.com"]
-  spec.summary       = "Allows VCR to automatically make cassetes with proper file paths with MiniTest"
-  spec.description   = "I like MiniTest.  I like VCR.  I like not having to manage cassetes."
+  spec.summary       = "Allows VCR to automatically make cassetes with proper file paths with minitest"
+  spec.description   = "I like minitest. I like VCR. I like not having to manage cassetes."
   spec.homepage      = ""
   spec.license       = "MIT"
 
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "vcr",                            ">= 2.9"
-  spec.add_dependency "minitest",                       ">= 4.7.5"
-  spec.add_dependency "minispec-metadata",              "~> 2.0"
+  spec.add_dependency "minitest",                       ">= 5.19.0"
+  spec.add_dependency "minispec-metadata",              ">= 2.0"
 
   spec.add_development_dependency "bundler",            "~> 1.5"
   spec.add_development_dependency "rake",               "~> 10.0"

--- a/test/minitest-vcr/spec_test.rb
+++ b/test/minitest-vcr/spec_test.rb
@@ -44,8 +44,8 @@ describe MinitestVcr::Spec do
   describe "#configure!", :vcr do
 
     before do
-      ::MiniTest::Spec.expects(:before).with(:each)
-      ::MiniTest::Spec.expects(:after).with(:each)
+      ::Minitest::Spec.expects(:before).with(:each)
+      ::Minitest::Spec.expects(:after).with(:each)
     end
 
     it "should call before and after with proper args and block" do


### PR DESCRIPTION
The rename happened in 5.0, but 5.19.0 started to only define the old alias when `ENV["MT_COMPAT"]` is defined, which usually is not the case